### PR TITLE
Create GitHub workflow to build and host war file

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -1,51 +1,52 @@
 name: Build and Deploy
 
+# Define the events that trigger the workflow
 on:
-  push:
+  push: # Trigger on push events to the main branch
     branches:
       - main
-  pull_request:
+  pull_request: # Trigger on pull request events to the main branch
     branches:
       - main
-  release:
+  release: # Trigger on release creation
     types: [created]
-  workflow_dispatch:
+  workflow_dispatch: # Allow manual triggering of the workflow
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest # Use the latest Ubuntu runner
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3 # Check out the repository code
 
       - name: Set up Java 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v3 # Set up Java 17 environment
         with:
           java-version: '17'
           distribution: 'temurin'
 
       - name: Build with Maven
-        run: mvn install
+        run: mvn install # Build the project using Maven
 
       - name: Upload war file
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v3 # Upload the built WAR file as an artifact
         with:
           name: war-file
           path: target/*.war
 
   upload-release-asset:
-    needs: build
-    runs-on: ubuntu-latest
-    if: github.event_name == 'release'
+    needs: build # This job depends on the build job
+    runs-on: ubuntu-latest # Use the latest Ubuntu runner
+    if: github.event_name == 'release' # Only run this job on release events
     steps:
       - name: Check out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3 # Check out the repository code
 
       - name: Upload war file to GitHub package
-        uses: actions/upload-release-asset@v1
+        uses: actions/upload-release-asset@v1 # Upload the WAR file to the release
         with:
-          upload_url: ${{ github.event.release.upload_url }}
+          upload_url: ${{ github.event.release.upload_url }} # Use the release upload URL
           asset_path: target/*.war
           asset_name: sample.war
           asset_content_type: application/zip

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
     branches:
       - main
+  release:
+    types: [created]
+  workflow_dispatch:
 
 jobs:
   build:
@@ -20,7 +23,8 @@ jobs:
         uses: actions/setup-java@v3
         with:
           java-version: '17'
-          distribution: 'temurin'  # or your preferred distribution
+          distribution: 'temurin'
+
       - name: Build with Maven
         run: mvn install
 
@@ -29,6 +33,14 @@ jobs:
         with:
           name: war-file
           path: target/*.war
+
+  upload-release-asset:
+    needs: build
+    runs-on: ubuntu-latest
+    if: github.event_name == 'release'
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v3
 
       - name: Upload war file to GitHub package
         uses: actions/upload-release-asset@v1

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -1,0 +1,39 @@
+name: Build and Deploy
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v2
+
+      - name: Set up Java 17
+        uses: actions/setup-java@v2
+        with:
+          java-version: '17'
+
+      - name: Build with Maven
+        run: mvn install
+
+      - name: Upload war file
+        uses: actions/upload-artifact@v2
+        with:
+          name: war-file
+          path: target/*.war
+
+      - name: Upload war file to GitHub package
+        uses: actions/upload-release-asset@v1
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: target/*.war
+          asset_name: sample.war
+          asset_content_type: application/zip

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -20,6 +20,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           java-version: '17'
+          distribution: 'temurin'  # or your preferred distribution
       - name: Build with Maven
         run: mvn install
 

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -24,7 +24,7 @@ jobs:
         run: mvn install
 
       - name: Upload war file
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: war-file
           path: target/*.war

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -14,13 +14,12 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Java 17
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           java-version: '17'
-
       - name: Build with Maven
         run: mvn install
 


### PR DESCRIPTION
Related to #3

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/gounthar/tp07-sample/issues/3?shareId=5d0123e0-d0ce-4a46-bc37-cfcafb18fea1).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced an automated GitHub Actions workflow for building and deploying the Java application.
	- The workflow includes steps for checking out the repository, setting up Java 17, building the project, and uploading the WAR file as a release asset.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->