### PR TITLE
Automatically create a new release

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -9,7 +9,7 @@ on:
     branches:
       - main
   release: # Trigger on release creation
-    types: [created]
+    types: [ created ]
   workflow_dispatch: # Allow manual triggering of the workflow
 
 jobs:
@@ -64,6 +64,10 @@ jobs:
           git config --global user.name 'github-actions'
           git config --global user.email 'github-actions@github.com'
 
+      - name: Get version
+        id: version
+        run: echo "version=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)" >> $GITHUB_OUTPUT
+
       - name: Update project version
         run: mvn versions:set -DnewVersion="$(date +'%Y.%m.%d-%H%M%S')" # Update the project version using the current date and time
 
@@ -73,9 +77,12 @@ jobs:
           git commit -m "Update project version to $(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)"
 
       - name: Create release
-        uses: actions/create-release@v1 # Create a new release
+        uses: softprops/action-gh-release@v1 # Create a new release
         with:
-          tag_name: $(date +'%Y%m%d%H%M%S') # Use the current date and time as the tag name
-          release_name: Release $(date +'%Y%m%d%H%M%S') # Use the current date and time as the release name
+          tag_name: ${{ format('v{0}', steps.version.outputs.version) }} # Use the version from the previous step
+          name: Release ${{ format('v{0}', steps.version.outputs.version) }} # Use the version from the previous step
           draft: false
           prerelease: false
+
+      - name: Push changes
+        run: git push

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -50,3 +50,32 @@ jobs:
           asset_path: target/*.war
           asset_name: sample.war
           asset_content_type: application/zip
+
+  create-release:
+    needs: build # This job depends on the build job
+    runs-on: ubuntu-latest # Use the latest Ubuntu runner
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main' # Only run this job on push events to the main branch
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4 # Check out the repository code
+
+      - name: Set up Git
+        run: |
+          git config --global user.name 'github-actions'
+          git config --global user.email 'github-actions@github.com'
+
+      - name: Update project version
+        run: mvn versions:set -DnewVersion=$(date +'%Y%m%d%H%M%S') # Update the project version using the current date and time
+
+      - name: Commit updated pom.xml
+        run: |
+          git add pom.xml
+          git commit -m 'Update project version'
+
+      - name: Create release
+        uses: actions/create-release@v1 # Create a new release
+        with:
+          tag_name: $(date +'%Y%m%d%H%M%S') # Use the current date and time as the tag name
+          release_name: Release $(date +'%Y%m%d%H%M%S') # Use the current date and time as the release name
+          draft: false
+          prerelease: false

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -65,12 +65,12 @@ jobs:
           git config --global user.email 'github-actions@github.com'
 
       - name: Update project version
-        run: mvn versions:set -DnewVersion=$(date +'%Y%m%d%H%M%S') # Update the project version using the current date and time
+        run: mvn versions:set -DnewVersion="$(date +'%Y.%m.%d-%H%M%S')" # Update the project version using the current date and time
 
       - name: Commit updated pom.xml
         run: |
           git add pom.xml
-          git commit -m 'Update project version'
+          git commit -m "Update project version to $(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)"
 
       - name: Create release
         uses: actions/create-release@v1 # Create a new release

--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,30 @@
                     <artifactId>maven-resources-plugin</artifactId>
                     <version>3.3.1</version>
                 </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-git-commit-id-plugin</artifactId>
+                    <version>4.0.0</version>
+                    <executions>
+                        <execution>
+                            <goals>
+                                <goal>revision</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>versions-maven-plugin</artifactId>
+                    <version>2.8.1</version>
+                    <executions>
+                        <execution>
+                            <goals>
+                                <goal>set</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
             </plugins>
         </pluginManagement>
     </build>


### PR DESCRIPTION
Fixes #16

Add steps to automatically create a new release upon merging a PR to the main branch.

* **pom.xml**
  - Add `maven-git-commit-id-plugin` to generate the Git commit ID.
  - Add `versions-maven-plugin` to update the project version.

* **.github/workflows/build-and-deploy.yml**
  - Add a new job `create-release` that depends on the `build` job.
  - Use `actions/create-release@v1` to create a new release with the tag name and release name based on the current date and time.
  - Add a step to update the project version using the `versions-maven-plugin`.
  - Add a step to commit the updated `pom.xml` file with the new version.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/gounthar/tp07-sample/issues/16?shareId=a21f92fb-4867-4004-a10d-c5f23f07bcb4).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced a new automated release process that triggers on main branch pushes, enhancing deployment efficiency.
- **Improvements**
	- Updated build configuration to include new plugins for better version management and Git commit ID retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->