### PR TITLE
feat(setup): automate JDK 21 Temurin install and Gitpod integration

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,9 @@
+tasks:
+  - name: Setup JDK 21 (Temurin) and Build
+    init: bash setup_jdk21_and_mvn.sh
+    command: echo "Java 21 Temurin installed and Maven build complete."
+
+# Optionally, expose ports or set up VS Code extensions here
+# ports:
+#   - port: 8080
+#     onOpen: open-preview

--- a/setup_jdk21_and_mvn.sh
+++ b/setup_jdk21_and_mvn.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -eo pipefail
 # Install SDKMAN if not already installed
 if [ ! -d "$HOME/.sdkman" ]; then
   curl -s "https://get.sdkman.io" | bash
@@ -18,14 +19,14 @@ fi
 
 
 # Find the latest Java 21 Temurin version
-LATEST_JAVA21_TEM=$(sdk list java | grep -E '21\\.[0-9]+\\.[0-9]+-tem' | awk '{print $NF}' | sort -V | tail -1)
+LATEST_JAVA21_TEM=$(sdk list java | grep -E '21(\.[0-9]+)+-tem' | awk '{print $NF}' | sort -V | tail -1)
 if [ -z "$LATEST_JAVA21_TEM" ]; then
   echo "No Java 21 Temurin version found via SDKMAN. Exiting."
   exit 1
 fi
 
 # Install and set as default, auto-confirming prompts
-yes | sdk install java "$LATEST_JAVA21_TEM"
+sdk install java "$LATEST_JAVA21_TEM" -y
 
 # Print Java version for verification
 java -version

--- a/setup_jdk21_and_mvn.sh
+++ b/setup_jdk21_and_mvn.sh
@@ -19,7 +19,19 @@ fi
 
 
 # Find the latest Java 21 Temurin version
-LATEST_JAVA21_TEM=$(sdk list java | grep -E '21(\.[0-9]+)+-tem' | awk '{print $NF}' | sort -V | tail -1)
+LATEST_JAVA21_TEM=$(
+  sdk list java | awk -F '|' '
+    /\|\s*Identifier\s*$/ { idcol=NF; next }
+    idcol && $idcol ~ /21(\.[0-9]+)+-tem$/ {
+      gsub(/^[ \t]+|[ \t]+$/, "", $idcol);
+      print $idcol
+    }
+  ' | sort -V | tail -1
+)
+if [ -z "$LATEST_JAVA21_TEM" ]; then
+  echo "Could not determine latest Java 21 Temurin identifier from SDKMAN output." >&2
+  exit 1
+fi
 if [ -z "$LATEST_JAVA21_TEM" ]; then
   echo "No Java 21 Temurin version found via SDKMAN. Exiting."
   exit 1

--- a/setup_jdk21_and_mvn.sh
+++ b/setup_jdk21_and_mvn.sh
@@ -44,5 +44,8 @@ sdk default java "$LATEST_JAVA21_TEM"
 # Print Java version for verification
 java -version
 
-# Run Maven install
-mvn install
+# Run Maven install (ensure Maven exists; batch mode for CI/IDE logs)
+if ! command -v mvn >/dev/null 2>&1; then
+  sdk install maven -y
+fi
+mvn -B -ntp install

--- a/setup_jdk21_and_mvn.sh
+++ b/setup_jdk21_and_mvn.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# Install SDKMAN if not already installed
+if [ ! -d "$HOME/.sdkman" ]; then
+  curl -s "https://get.sdkman.io" | bash
+fi
+
+
+# Load SDKMAN into the current shell session (try $HOME, then /usr/local)
+if [ -s "$HOME/.sdkman/bin/sdkman-init.sh" ]; then
+  source "$HOME/.sdkman/bin/sdkman-init.sh"
+elif [ -s "/usr/local/sdkman/bin/sdkman-init.sh" ]; then
+  source "/usr/local/sdkman/bin/sdkman-init.sh"
+else
+  echo "SDKMAN init script not found. Exiting."
+  exit 1
+fi
+
+
+
+# Find the latest Java 21 Temurin version
+LATEST_JAVA21_TEM=$(sdk list java | grep -E '21\\.[0-9]+\\.[0-9]+-tem' | awk '{print $NF}' | sort -V | tail -1)
+if [ -z "$LATEST_JAVA21_TEM" ]; then
+  echo "No Java 21 Temurin version found via SDKMAN. Exiting."
+  exit 1
+fi
+
+# Install and set as default, auto-confirming prompts
+yes | sdk install java "$LATEST_JAVA21_TEM"
+
+# Print Java version for verification
+java -version
+
+# Run Maven install
+mvn install

--- a/setup_jdk21_and_mvn.sh
+++ b/setup_jdk21_and_mvn.sh
@@ -2,7 +2,7 @@
 set -eo pipefail
 # Install SDKMAN if not already installed
 if [ ! -d "$HOME/.sdkman" ]; then
-  curl -s "https://get.sdkman.io" | bash
+  curl -fsSL "https://get.sdkman.io" | bash
 fi
 
 
@@ -27,6 +27,7 @@ fi
 
 # Install and set as default, auto-confirming prompts
 sdk install java "$LATEST_JAVA21_TEM" -y
+sdk default java "$LATEST_JAVA21_TEM"
 
 # Print Java version for verification
 java -version


### PR DESCRIPTION
- Updated setup script to dynamically detect and install the latest Java 21 Temurin version using SDKMAN, removing hardcoded version dependency.
- Ensured the script auto-confirms prompts for non-interactive use.
- Added a .gitpod.yml configuration to run the setup script and Maven build automatically on Gitpod workspace start.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatically runs a Maven build after JDK setup.
* **Bug Fixes**
  * More reliable detection of the latest Java 21 Temurin version.
  * Improved error handling, including proper handling of failures in chained commands.
* **Chores**
  * Installation is now non-interactive for smoother automation.
  * General script hardening to reduce setup flakiness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->